### PR TITLE
Update default values for sTFMesTextBox and aFMesTextBox

### DIFF
--- a/orcToDh/mainPage.Designer.cs
+++ b/orcToDh/mainPage.Designer.cs
@@ -134,7 +134,7 @@
             sTFMesTextBox.Name = "sTFMesTextBox";
             sTFMesTextBox.Size = new Size(100, 23);
             sTFMesTextBox.TabIndex = 9;
-            sTFMesTextBox.Text = "1170";
+            sTFMesTextBox.Text = "0";
             sTFMesTextBox.TextChanged += textBox1_TextChanged;
             // 
             // aFMesTextBox
@@ -143,7 +143,7 @@
             aFMesTextBox.Name = "aFMesTextBox";
             aFMesTextBox.Size = new Size(100, 23);
             aFMesTextBox.TabIndex = 10;
-            aFMesTextBox.Text = "180";
+            aFMesTextBox.Text = "0";
             aFMesTextBox.TextChanged += textBox2_TextChanged;
             // 
             // bowpointLable


### PR DESCRIPTION
The initial values of the `sTFMesTextBox` and `aFMesTextBox` text boxes have been changed. Previously, `sTFMesTextBox` had a default text value of "1170", which has now been changed to "0". Similarly, `aFMesTextBox` had a default text value of "180", which has also been changed to "0".