### PR TITLE
Add error handling for integer parsing from text boxes

### DIFF
--- a/orcToDh/mainPage.cs
+++ b/orcToDh/mainPage.cs
@@ -39,8 +39,15 @@ namespace orcToDh
 
         public void calculate()
         {
-            int aFMes = aFMesTextBox.Text == "" ? 0 : int.Parse(aFMesTextBox.Text);
-            int sTFMes = sTFMesTextBox.Text == "" ? 0 : int.Parse(sTFMesTextBox.Text);
+            int aFMes;
+            int sTFMes;
+            try
+            {
+                aFMes = aFMesTextBox.Text == "" ? 0 : int.Parse(aFMesTextBox.Text);
+                sTFMes = sTFMesTextBox.Text == "" ? 0 : int.Parse(sTFMesTextBox.Text);
+            } catch (FormatException) {
+                return;
+            }
             ofset.AF = aFMes;
             ofset.STF = sTFMes;
             bMaxCalculator = new(ofset);


### PR DESCRIPTION
Introduced a try-catch block to handle FormatException errors when parsing text box inputs to integers. If a FormatException is caught, the function returns immediately, preventing further execution with invalid input.